### PR TITLE
fix: typescript dependency is not needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11",
     "eslint-plugin-promise": "^6",
-    "jest": "^29",
-    "typescript": ">=2.8.2"
+    "jest": "^29"
   },
   "peerDependencies": {
     "eslint": "^8",
@@ -37,8 +36,7 @@
     "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11",
     "eslint-plugin-promise": "^6",
-    "eslint-plugin-jsdoc": "^42",
-    "typescript": ">=2.8.2"
+    "eslint-plugin-jsdoc": "^42"
   },
   "author": "Adobe Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
closes #55

Related: https://github.com/adobe/aio-cli-plugin-app/issues/759
This has to be a MAJOR version release.

## How Has This Been Tested?

- update the plugin above with the branch version of this config (see repo README - use `adobe/eslint-config-aio-lib-config#remove-ts`)
- remove `typescript` `devDep` in the plugin repo
- delete `node_modules`, run `npm i`
- run `npm test`
- run `npm prepack`
- check README `See code:` section of a command, should have file extension `.js`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
