### PR TITLE
run on node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/eslint-config-aio-lib-config",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Shareable ESLint config for AIO libs",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "eslint-config-standard": "^17",
     "eslint-plugin-import": "^2",
     "eslint-plugin-jest": "^27",
-    "eslint-plugin-jsdoc": "^42",
+    "eslint-plugin-jsdoc": "^43",
     "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11",
     "eslint-plugin-promise": "^6",
@@ -36,7 +36,7 @@
     "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11",
     "eslint-plugin-promise": "^6",
-    "eslint-plugin-jsdoc": "^42"
+    "eslint-plugin-jsdoc": "^43"
   },
   "author": "Adobe Inc.",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/eslint-config-aio-lib-config",
-  "version": "4.0.0",
+  "version": "3.0.1",
   "description": "Shareable ESLint config for AIO libs",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/eslint-config-aio-lib-config",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "Shareable ESLint config for AIO libs",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
     "eslint-config-standard": "^17",
     "eslint-plugin-import": "^2",
     "eslint-plugin-jest": "^27",
-    "eslint-plugin-jsdoc": "^43",
+    "eslint-plugin-jsdoc": "^48",
     "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11",
     "eslint-plugin-promise": "^6",
@@ -36,7 +36,7 @@
     "eslint-plugin-n": "^15.7",
     "eslint-plugin-node": "^11",
     "eslint-plugin-promise": "^6",
-    "eslint-plugin-jsdoc": "^43"
+    "eslint-plugin-jsdoc": "^48"
   },
   "author": "Adobe Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

Allows to run on node 20

## Related Issue

Fixes #56 

## Motivation and Context

Transitive dependency for aio RDE plugins that currently run on Node16 which is end of life, needs an upgrade to run on node 20.

## How Has This Been Tested?

Local test using RDEs, as described in https://experienceleague.adobe.com/docs/experience-manager-learn/cloud-service/developing/rde/how-to-setup.html

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
